### PR TITLE
Fix build on x86_64 by enabling yasm dependency

### DIFF
--- a/rpm/libav.spec
+++ b/rpm/libav.spec
@@ -8,7 +8,7 @@ Source:         %{name}-%{version}.tar.gz
 Patch0:         0001-Fix-linking-errors-when-VC1-parser-is-enabled-and-VC.patch
 License:        LGPLv2+
 BuildRequires:  pkgconfig(speex)
-%ifarch i486
+%ifarch i486 x86_64
 BuildRequires:  yasm
 %endif
 


### PR DESCRIPTION
Tested on OBS against mer:core and package goes from _failed_ to _success_ for **x86_64**.